### PR TITLE
Silent Pings by default

### DIFF
--- a/src/bot/prompt/base.prompt.ts
+++ b/src/bot/prompt/base.prompt.ts
@@ -1,8 +1,10 @@
-import { BaseMessageOptions } from 'discord.js';
-import { countBy, mergeWith } from 'lodash';
+import { BaseMessageOptions, MessageCreateOptions, MessageFlags } from 'discord.js';
+import { mergeWith } from 'lodash';
 
 export class BasePromptBuilder {
-  public static base: BaseMessageOptions = {};
+  public static base: MessageCreateOptions = {
+    flags: [MessageFlags.SuppressNotifications],
+  };
   private options: BaseMessageOptions[];
 
   constructor(options: BaseMessageOptions = {}) {

--- a/src/bot/prompt/base.prompt.ts
+++ b/src/bot/prompt/base.prompt.ts
@@ -8,7 +8,7 @@ export class BasePromptBuilder {
   private options: BaseMessageOptions[];
 
   constructor(options: BaseMessageOptions = {}) {
-    this.options = [{ ...options, ...(this.constructor as typeof BasePromptBuilder).base }];
+    this.options = [{ ...(this.constructor as typeof BasePromptBuilder).base, ...options }];
   }
 
   private static customizer(objValue: any, srcValue: any) {


### PR DESCRIPTION
- adds the [SupressNotifications Flag](https://discord-api-types.dev/api/discord-api-types-v10/enum/MessageFlags#SuppressNotifications) to the base prompt.
- adjust the base prompt constructor so that passed options override the base.